### PR TITLE
Only send system info on first launch after install

### DIFF
--- a/dist/DeepLinkIapProvider.js
+++ b/dist/DeepLinkIapProvider.js
@@ -153,7 +153,7 @@ const DeepLinkIapProvider = ({ children, }) => {
         }
         if (insertLinksEnabledParam && react_native_1.Platform.OS === 'ios') {
             const systemInfoSent = yield getValueFromAsync(ASYNC_KEYS.SYSTEM_INFO_SENT);
-            console.log(`[Insert Affiliate] System info sent flag: "${systemInfoSent}" (type: ${typeof systemInfoSent})`);
+            verboseLog(`System info sent flag: ${systemInfoSent ? 'true (skipping)' : 'false (will send)'}`);
             if (!systemInfoSent) {
                 // Set flag immediately to prevent concurrent init calls from sending twice
                 yield saveValueInAsync(ASYNC_KEYS.SYSTEM_INFO_SENT, 'pending');

--- a/dist/DeepLinkIapProvider.js
+++ b/dist/DeepLinkIapProvider.js
@@ -56,6 +56,7 @@ const ASYNC_KEYS = {
     AFFILIATE_STORED_DATE: '@app_affiliate_stored_date',
     SDK_INIT_REPORTED: '@app_sdk_init_reported',
     REPORTED_AFFILIATE_ASSOCIATIONS: '@app_reported_affiliate_associations',
+    SYSTEM_INFO_SENT: '@app_system_info_sent',
 };
 // STARTING CONTEXT IMPLEMENTATION
 exports.DeepLinkIapContext = (0, react_1.createContext)({
@@ -151,12 +152,20 @@ const DeepLinkIapProvider = ({ children, }) => {
             }
         }
         if (insertLinksEnabledParam && react_native_1.Platform.OS === 'ios') {
-            try {
-                const enhancedSystemInfo = yield getEnhancedSystemInfo();
-                yield sendSystemInfoToBackend(enhancedSystemInfo);
-            }
-            catch (error) {
-                verboseLog(`Error sending system info for clipboard check: ${error}`);
+            const systemInfoSent = yield getValueFromAsync(ASYNC_KEYS.SYSTEM_INFO_SENT);
+            console.log(`[Insert Affiliate] System info sent flag: "${systemInfoSent}" (type: ${typeof systemInfoSent})`);
+            if (!systemInfoSent) {
+                // Set flag immediately to prevent concurrent init calls from sending twice
+                yield saveValueInAsync(ASYNC_KEYS.SYSTEM_INFO_SENT, 'pending');
+                try {
+                    const enhancedSystemInfo = yield getEnhancedSystemInfo();
+                    yield sendSystemInfoToBackend(enhancedSystemInfo);
+                }
+                catch (error) {
+                    // Remove flag on failure so it retries next launch
+                    yield async_storage_1.default.removeItem(ASYNC_KEYS.SYSTEM_INFO_SENT);
+                    verboseLog(`Error sending system info for clipboard check: ${error}`);
+                }
             }
         }
     });
@@ -561,14 +570,7 @@ const DeepLinkIapProvider = ({ children, }) => {
             }
             // If URL scheme is used, we can straight away store the short code as the referring link
             yield storeInsertAffiliateIdentifier({ link: shortCode, source: 'deep_link_ios' });
-            // Collect and send enhanced system info to backend
-            try {
-                const enhancedSystemInfo = yield getEnhancedSystemInfo();
-                yield sendSystemInfoToBackend(enhancedSystemInfo);
-            }
-            catch (error) {
-                verboseLog(`Error sending system info for deep link: ${error}`);
-            }
+            // System info not needed here - affiliate code already received via URL scheme
             return true;
         }
         catch (error) {
@@ -1162,6 +1164,7 @@ const DeepLinkIapProvider = ({ children, }) => {
             }
             // Check for a successful response
             if (response.status >= 200 && response.status <= 299) {
+                yield saveValueInAsync(ASYNC_KEYS.SYSTEM_INFO_SENT, 'true');
                 verboseLog('System info sent successfully');
             }
             else {

--- a/src/DeepLinkIapProvider.tsx
+++ b/src/DeepLinkIapProvider.tsx
@@ -83,6 +83,7 @@ const ASYNC_KEYS = {
   AFFILIATE_STORED_DATE: '@app_affiliate_stored_date',
   SDK_INIT_REPORTED: '@app_sdk_init_reported',
   REPORTED_AFFILIATE_ASSOCIATIONS: '@app_reported_affiliate_associations',
+  SYSTEM_INFO_SENT: '@app_system_info_sent',
 };
 
 // Source types for affiliate association tracking
@@ -207,11 +208,14 @@ const DeepLinkIapProvider: React.FC<T_DEEPLINK_IAP_PROVIDER> = ({
     }
 
     if (insertLinksEnabledParam && Platform.OS === 'ios') {
-      try {
-        const enhancedSystemInfo = await getEnhancedSystemInfo();
-        await sendSystemInfoToBackend(enhancedSystemInfo);
-      } catch (error) {
-        verboseLog(`Error sending system info for clipboard check: ${error}`);
+      const systemInfoSent = await getValueFromAsync(ASYNC_KEYS.SYSTEM_INFO_SENT);
+      if (!systemInfoSent) {
+        try {
+          const enhancedSystemInfo = await getEnhancedSystemInfo();
+          await sendSystemInfoToBackend(enhancedSystemInfo);
+        } catch (error) {
+          verboseLog(`Error sending system info for clipboard check: ${error}`);
+        }
       }
     }
   };
@@ -1347,6 +1351,7 @@ const DeepLinkIapProvider: React.FC<T_DEEPLINK_IAP_PROVIDER> = ({
       
       // Check for a successful response
       if (response.status >= 200 && response.status <= 299) {
+        await saveValueInAsync(ASYNC_KEYS.SYSTEM_INFO_SENT, 'true');
         verboseLog('System info sent successfully');
       } else {
         verboseLog(`Failed to send system info with status code: ${response.status}`);

--- a/src/DeepLinkIapProvider.tsx
+++ b/src/DeepLinkIapProvider.tsx
@@ -211,10 +211,14 @@ const DeepLinkIapProvider: React.FC<T_DEEPLINK_IAP_PROVIDER> = ({
       const systemInfoSent = await getValueFromAsync(ASYNC_KEYS.SYSTEM_INFO_SENT);
       verboseLog(`System info sent flag: ${systemInfoSent ? 'true (skipping)' : 'false (will send)'}`);
       if (!systemInfoSent) {
+        // Set flag immediately to prevent concurrent init calls from sending twice
+        await saveValueInAsync(ASYNC_KEYS.SYSTEM_INFO_SENT, 'pending');
         try {
           const enhancedSystemInfo = await getEnhancedSystemInfo();
           await sendSystemInfoToBackend(enhancedSystemInfo);
         } catch (error) {
+          // Remove flag on failure so it retries next launch
+          await AsyncStorage.removeItem(ASYNC_KEYS.SYSTEM_INFO_SENT);
           verboseLog(`Error sending system info for clipboard check: ${error}`);
         }
       }

--- a/src/DeepLinkIapProvider.tsx
+++ b/src/DeepLinkIapProvider.tsx
@@ -209,7 +209,7 @@ const DeepLinkIapProvider: React.FC<T_DEEPLINK_IAP_PROVIDER> = ({
 
     if (insertLinksEnabledParam && Platform.OS === 'ios') {
       const systemInfoSent = await getValueFromAsync(ASYNC_KEYS.SYSTEM_INFO_SENT);
-      verboseLog(`System info sent flag: ${systemInfoSent ? 'true (skipping)' : 'false (will send)'}`);
+      console.log(`[Insert Affiliate] System info sent flag: "${systemInfoSent}" (type: ${typeof systemInfoSent})`);
       if (!systemInfoSent) {
         // Set flag immediately to prevent concurrent init calls from sending twice
         await saveValueInAsync(ASYNC_KEYS.SYSTEM_INFO_SENT, 'pending');

--- a/src/DeepLinkIapProvider.tsx
+++ b/src/DeepLinkIapProvider.tsx
@@ -668,13 +668,7 @@ const DeepLinkIapProvider: React.FC<T_DEEPLINK_IAP_PROVIDER> = ({
       // If URL scheme is used, we can straight away store the short code as the referring link
       await storeInsertAffiliateIdentifier({ link: shortCode, source: 'deep_link_ios' });
 
-      // Collect and send enhanced system info to backend
-      try {
-        const enhancedSystemInfo = await getEnhancedSystemInfo();
-        await sendSystemInfoToBackend(enhancedSystemInfo);
-      } catch (error) {
-        verboseLog(`Error sending system info for deep link: ${error}`);
-      }
+      // System info not needed here - affiliate code already received via URL scheme
 
       return true;
     } catch (error) {

--- a/src/DeepLinkIapProvider.tsx
+++ b/src/DeepLinkIapProvider.tsx
@@ -209,6 +209,7 @@ const DeepLinkIapProvider: React.FC<T_DEEPLINK_IAP_PROVIDER> = ({
 
     if (insertLinksEnabledParam && Platform.OS === 'ios') {
       const systemInfoSent = await getValueFromAsync(ASYNC_KEYS.SYSTEM_INFO_SENT);
+      verboseLog(`System info sent flag: ${systemInfoSent ? 'true (skipping)' : 'false (will send)'}`);
       if (!systemInfoSent) {
         try {
           const enhancedSystemInfo = await getEnhancedSystemInfo();

--- a/src/DeepLinkIapProvider.tsx
+++ b/src/DeepLinkIapProvider.tsx
@@ -209,7 +209,7 @@ const DeepLinkIapProvider: React.FC<T_DEEPLINK_IAP_PROVIDER> = ({
 
     if (insertLinksEnabledParam && Platform.OS === 'ios') {
       const systemInfoSent = await getValueFromAsync(ASYNC_KEYS.SYSTEM_INFO_SENT);
-      console.log(`[Insert Affiliate] System info sent flag: "${systemInfoSent}" (type: ${typeof systemInfoSent})`);
+      verboseLog(`System info sent flag: ${systemInfoSent ? 'true (skipping)' : 'false (will send)'}`);
       if (!systemInfoSent) {
         // Set flag immediately to prevent concurrent init calls from sending twice
         await saveValueInAsync(ASYNC_KEYS.SYSTEM_INFO_SENT, 'pending');


### PR DESCRIPTION
## Summary
- System info for deferred deep link matching is now sent only once per install
- On successful send, a flag is persisted to AsyncStorage to prevent redundant network calls on subsequent launches
- If the send fails, the flag is removed so it retries on next launch
- Removed unnecessary system info call from handleCustomURLScheme (was triggering iOS clipboard paste prompt on every link click)
- Race condition guard: flag set to 'pending' immediately before async work to prevent concurrent init calls

## Test plan
- [x] Fresh install: system info sent, probabilistic match works
- [x] Subsequent launches: system info skipped (flag = "true")
- [x] Direct deep link via URL scheme: no system info sent, no clipboard prompt
- [x] Affiliate replacement: clicking different link replaces stored affiliate