### PR TITLE
Add Universal Links and Android App Links support

### DIFF
--- a/dist/DeepLinkIapProvider.js
+++ b/dist/DeepLinkIapProvider.js
@@ -529,6 +529,7 @@ const DeepLinkIapProvider = ({ children, }) => {
     });
     // Handles Insert Links deep linking - equivalent to iOS handleInsertLinks
     const handleInsertLinksImpl = (url) => __awaiter(void 0, void 0, void 0, function* () {
+        var _a;
         try {
             loggerRef.current.info(`Attempting to handle URL: ${url}`);
             if (!url || typeof url !== 'string') {
@@ -545,10 +546,15 @@ const DeepLinkIapProvider = ({ children, }) => {
             if (urlObj.protocol && urlObj.protocol.startsWith('ia-')) {
                 return yield handleCustomURLScheme(url, urlObj.protocol);
             }
-            // Handle universal links (https://insertaffiliate.link/V1/companycode/shortcode)
-            // if (urlObj.protocol === 'https:' && urlObj.hostname?.includes('insertaffiliate.link')) {
-            //   return await handleUniversalLink(urlObj);
-            // }
+            // Handle universal links from insertaffiliate.link
+            if (urlObj.protocol === 'https:' && ((_a = urlObj.hostname) === null || _a === void 0 ? void 0 : _a.includes('insertaffiliate.link'))) {
+                return yield handleUniversalLink(url);
+            }
+            // Handle universal links from any https domain (custom domains)
+            // iOS only delivers universal links for domains in Associated Domains entitlement
+            if (urlObj.protocol === 'https:') {
+                return yield handleCustomDomainUniversalLink(url);
+            }
             return false;
         }
         catch (error) {
@@ -587,31 +593,70 @@ const DeepLinkIapProvider = ({ children, }) => {
             return false;
         }
     });
-    // Handle universal links like https://insertaffiliate.link/V1/companycode/shortcode
-    // const handleUniversalLink = async (url: URL): Promise<boolean> => {
-    //   try {
-    //     const pathComponents = url.pathname.split('/').filter(segment => segment.length > 0);
-    //     // Expected format: /V1/companycode/shortcode
-    //     if (pathComponents.length < 3 || pathComponents[0] !== 'V1') {
-    //       loggerRef.current.info(`Invalid universal link format: ${url.href}`);
-    //       return false;
-    //     }
-    //     const companyCode = pathComponents[1];
-    //     const shortCode = pathComponents[2];
-    //     loggerRef.current.info(`Universal link detected - Company: ${companyCode}, Short code: ${shortCode}`);
-    //     // Validate company code matches initialized one
-    //     const activeCompanyCode = await getActiveCompanyCode();
-    //     if (activeCompanyCode && companyCode.toLowerCase() !== activeCompanyCode.toLowerCase()) {
-    //       loggerRef.current.info(`Warning: URL company code (${companyCode}) doesn't match initialized company code (${activeCompanyCode})`);
-    //     }
-    //     // Process the affiliate attribution
-    //     await storeInsertAffiliateIdentifier({ link: shortCode });
-    //     return true;
-    //   } catch (error) {
-    //     loggerRef.current.error('Error handling universal link:', error);
-    //     return false;
-    //   }
-    // };
+    // Handle universal links like https://insertaffiliate.link/companycode/shortcode
+    // Also supports legacy format: https://insertaffiliate.link/V1/companycode/shortcode
+    const handleUniversalLink = (url) => __awaiter(void 0, void 0, void 0, function* () {
+        try {
+            const pathMatch = url.match(/^https?:\/\/[^\/]+(\/.*)?$/);
+            const pathname = (pathMatch === null || pathMatch === void 0 ? void 0 : pathMatch[1]) || '';
+            const pathComponents = pathname.split('/').filter(segment => segment.length > 0);
+            let companyCode;
+            let shortCode;
+            if (pathComponents.length >= 3 && pathComponents[0] === 'V1') {
+                // Legacy format: /V1/companycode/shortcode
+                companyCode = pathComponents[1];
+                shortCode = pathComponents[2];
+            }
+            else if (pathComponents.length >= 2) {
+                // Current format: /companycode/shortcode
+                companyCode = pathComponents[0];
+                shortCode = pathComponents[1];
+            }
+            else {
+                loggerRef.current.info(`Invalid universal link format: ${url}`);
+                return false;
+            }
+            loggerRef.current.info(`Universal link detected - Company: ${companyCode}, Short code: ${shortCode}`);
+            const activeCompanyCode = yield getActiveCompanyCode();
+            if (activeCompanyCode && companyCode.toLowerCase() !== activeCompanyCode.toLowerCase()) {
+                loggerRef.current.info(`Warning: URL company code (${companyCode}) doesn't match initialized company code (${activeCompanyCode})`);
+            }
+            yield storeInsertAffiliateIdentifier({ link: shortCode, source: 'universal_link' });
+            return true;
+        }
+        catch (error) {
+            loggerRef.current.error('Error handling universal link:', error);
+            return false;
+        }
+    });
+    // Handle universal links from custom domains (e.g. https://links.yourcompany.com/companycode/shortcode)
+    // iOS only delivers universal links for domains in the app's Associated Domains entitlement
+    const handleCustomDomainUniversalLink = (url) => __awaiter(void 0, void 0, void 0, function* () {
+        try {
+            const pathMatch = url.match(/^https?:\/\/[^\/]+(\/.*)?$/);
+            const pathname = (pathMatch === null || pathMatch === void 0 ? void 0 : pathMatch[1]) || '';
+            const pathComponents = pathname.split('/').filter(segment => segment.length > 0);
+            if (pathComponents.length < 2) {
+                return false;
+            }
+            const urlCompanyCode = pathComponents[0];
+            const shortCode = pathComponents[1];
+            const activeCompanyCode = yield getActiveCompanyCode();
+            if (!activeCompanyCode)
+                return false;
+            if (urlCompanyCode.toLowerCase() !== activeCompanyCode.toLowerCase()) {
+                loggerRef.current.info(`Custom domain universal link company code (${urlCompanyCode}) doesn't match initialized company code (${activeCompanyCode}), ignoring`);
+                return false;
+            }
+            loggerRef.current.info(`Custom domain universal link detected - Short code: ${shortCode}`);
+            yield storeInsertAffiliateIdentifier({ link: shortCode, source: 'universal_link' });
+            return true;
+        }
+        catch (error) {
+            loggerRef.current.error('Error handling custom domain universal link:', error);
+            return false;
+        }
+    });
     // Parse short code from URL
     const parseShortCodeFromURL = (url) => {
         try {

--- a/dist/DeepLinkIapProvider.js
+++ b/dist/DeepLinkIapProvider.js
@@ -273,6 +273,12 @@ const DeepLinkIapProvider = ({ children, }) => {
         const handleDeepLink = (url) => __awaiter(void 0, void 0, void 0, function* () {
             try {
                 verboseLog(`Platform detection: Platform.OS = ${react_native_1.Platform.OS}`);
+                // App Links (Android) and Universal Links (iOS) both use https://
+                // Route these through handleInsertLinks which handles both
+                if (url.startsWith('https://') || url.startsWith('http://')) {
+                    verboseLog('Routing https URL to handleInsertLinks');
+                    return yield handleInsertLinks(url);
+                }
                 if (react_native_1.Platform.OS === 'ios') {
                     verboseLog('Routing to iOS handler (handleInsertLinks)');
                     return yield handleInsertLinks(url);
@@ -621,7 +627,7 @@ const DeepLinkIapProvider = ({ children, }) => {
             if (activeCompanyCode && companyCode.toLowerCase() !== activeCompanyCode.toLowerCase()) {
                 loggerRef.current.info(`Warning: URL company code (${companyCode}) doesn't match initialized company code (${activeCompanyCode})`);
             }
-            yield storeInsertAffiliateIdentifier({ link: shortCode, source: 'universal_link' });
+            yield storeInsertAffiliateIdentifier({ link: shortCode, source: react_native_1.Platform.OS === 'android' ? 'app_link' : 'universal_link' });
             return true;
         }
         catch (error) {
@@ -649,7 +655,7 @@ const DeepLinkIapProvider = ({ children, }) => {
                 return false;
             }
             loggerRef.current.info(`Custom domain universal link detected - Short code: ${shortCode}`);
-            yield storeInsertAffiliateIdentifier({ link: shortCode, source: 'universal_link' });
+            yield storeInsertAffiliateIdentifier({ link: shortCode, source: react_native_1.Platform.OS === 'android' ? 'app_link' : 'universal_link' });
             return true;
         }
         catch (error) {

--- a/readme.md
+++ b/readme.md
@@ -745,6 +745,43 @@ Update your `ios/YourApp/AppDelegate.mm`:
 }
 ```
 
+> **Note:** The `continueUserActivity` method above is required for Universal Links. Without it, tapping an Insert Link when the app is installed will open Safari instead of the app directly.
+
+#### Universal Links (Optional, Recommended)
+
+Universal Links provide a better user experience than custom URL schemes. When a user taps an Insert Link and already has your app installed, iOS opens the app directly — without loading the browser.
+
+**Prerequisites:**
+- Enter your **Apple Team ID** and **iOS Bundle Identifier** in the Insert Affiliate dashboard settings
+
+**Step 3a: Add Associated Domains in Xcode**
+
+Go to your app target → **Signing & Capabilities** → **+ Capability** → **Associated Domains**.
+
+Add:
+```
+applinks:insertaffiliate.link
+```
+
+If you have a custom domain (e.g. `links.yourcompany.com`), also add:
+```
+applinks:links.yourcompany.com
+```
+
+> The `continueUserActivity` method in Step 3 already handles Universal Links via `RCTLinkingManager` — no additional code changes needed.
+
+**Testing Universal Links:**
+
+```bash
+# iOS Simulator
+xcrun simctl openurl booted "https://insertaffiliate.link/YOUR_COMPANY_CODE/TEST_SHORT_CODE"
+
+# Real device (get UDID from: xcrun devicectl list devices)
+xcrun devicectl device process launch -d YOUR_DEVICE_UDID com.apple.mobilesafari "https://insertaffiliate.link/YOUR_COMPANY_CODE/TEST_SHORT_CODE"
+```
+
+> Universal Links won't trigger if you type the URL directly into Safari's address bar — tap it from **Notes or Messages** for a real test.
+
 **Step 4: Expo Router Setup (If Using Expo Router)**
 
 If you're using Expo Router, deep links will cause a "This screen does not exist" error because both the Insert Affiliate SDK and Expo Router try to handle the incoming URL. The SDK correctly processes the affiliate attribution, but Expo Router simultaneously attempts to navigate to the URL path (e.g., `/insert-affiliate`), which doesn't exist as a route.
@@ -775,8 +812,11 @@ See the [Expo Router +native-intent docs](https://docs.expo.dev/router/reference
 **Testing Deep Links:**
 
 ```bash
-# iOS Simulator
+# iOS Simulator - custom URL scheme
 xcrun simctl openurl booted "YOUR_IOS_URL_SCHEME://TEST_SHORT_CODE"
+
+# iOS Simulator - Universal Links
+xcrun simctl openurl booted "https://insertaffiliate.link/YOUR_COMPANY_CODE/TEST_SHORT_CODE"
 
 # Android Emulator
 adb shell am start -W -a android.intent.action.VIEW -d "YOUR_ANDROID_URL_SCHEME://TEST_SHORT_CODE"

--- a/readme.md
+++ b/readme.md
@@ -809,6 +809,41 @@ This ensures:
 
 See the [Expo Router +native-intent docs](https://docs.expo.dev/router/reference/native-intent/) for more details.
 
+#### Android App Links (Optional, Recommended)
+
+Android App Links provide a better user experience than custom URL schemes. When a user taps an Insert Link and already has your app installed, Android opens the app directly — without loading the browser or showing a disambiguation dialog.
+
+**Prerequisites:**
+- Enter your **Android Bundle Identifier** (package name) and **SHA-256 Certificate Fingerprints** in the Insert Affiliate dashboard settings
+
+**Step 1: Add intent filter to AndroidManifest.xml**
+
+Add this inside your main `<activity>` tag in `android/app/src/main/AndroidManifest.xml`:
+
+```xml
+<intent-filter android:autoVerify="true">
+    <action android:name="android.intent.action.VIEW" />
+    <category android:name="android.intent.category.DEFAULT" />
+    <category android:name="android.intent.category.BROWSABLE" />
+    <data android:scheme="https" android:host="insertaffiliate.link" />
+</intent-filter>
+```
+
+If you have a custom domain, add another intent filter with your domain.
+
+**Step 2: Set launch mode**
+
+Add `android:launchMode="singleTop"` to your main activity to prevent it being recreated when an App Link is tapped:
+
+```xml
+<activity
+    android:name=".MainActivity"
+    android:launchMode="singleTop"
+    ...>
+```
+
+> No additional code changes needed — the SDK's `Linking.addEventListener` already receives App Link URLs and routes them to the correct handler automatically.
+
 **Testing Deep Links:**
 
 ```bash
@@ -818,8 +853,8 @@ xcrun simctl openurl booted "YOUR_IOS_URL_SCHEME://TEST_SHORT_CODE"
 # iOS Simulator - Universal Links
 xcrun simctl openurl booted "https://insertaffiliate.link/YOUR_COMPANY_CODE/TEST_SHORT_CODE"
 
-# Android Emulator
-adb shell am start -W -a android.intent.action.VIEW -d "YOUR_ANDROID_URL_SCHEME://TEST_SHORT_CODE"
+# Android Emulator / Device
+adb shell am start -a android.intent.action.VIEW -d "https://insertaffiliate.link/YOUR_COMPANY_CODE/TEST_SHORT_CODE"
 ```
 
 **Insert Links setup complete!** Skip to [Verify Your Integration](#-verify-your-integration)

--- a/src/DeepLinkIapProvider.tsx
+++ b/src/DeepLinkIapProvider.tsx
@@ -94,7 +94,8 @@ type AffiliateAssociationSource =
   | 'install_referrer'   // Android Play Store install referrer
   | 'clipboard_match'    // iOS clipboard UUID match from backend
   | 'short_code_manual'  // Developer called setShortCode()
-  | 'referring_link';    // Developer called setInsertAffiliateIdentifier()
+  | 'referring_link'     // Developer called setInsertAffiliateIdentifier()
+  | 'universal_link';    // iOS Universal Link (https://insertaffiliate.link/companycode/shortcode)
 
 // Logger interface for custom logging
 export type InsertAffiliateLogger = {
@@ -647,10 +648,16 @@ const DeepLinkIapProvider: React.FC<T_DEEPLINK_IAP_PROVIDER> = ({
         return await handleCustomURLScheme(url, urlObj.protocol);
       }
 
-      // Handle universal links (https://insertaffiliate.link/V1/companycode/shortcode)
-      // if (urlObj.protocol === 'https:' && urlObj.hostname?.includes('insertaffiliate.link')) {
-      //   return await handleUniversalLink(urlObj);
-      // }
+      // Handle universal links from insertaffiliate.link
+      if (urlObj.protocol === 'https:' && urlObj.hostname?.includes('insertaffiliate.link')) {
+        return await handleUniversalLink(url);
+      }
+
+      // Handle universal links from any https domain (custom domains)
+      // iOS only delivers universal links for domains in Associated Domains entitlement
+      if (urlObj.protocol === 'https:') {
+        return await handleCustomDomainUniversalLink(url);
+      }
 
       return false;
     } catch (error) {
@@ -698,38 +705,76 @@ const DeepLinkIapProvider: React.FC<T_DEEPLINK_IAP_PROVIDER> = ({
     }
   };
 
-  // Handle universal links like https://insertaffiliate.link/V1/companycode/shortcode
-  // const handleUniversalLink = async (url: URL): Promise<boolean> => {
-  //   try {
-  //     const pathComponents = url.pathname.split('/').filter(segment => segment.length > 0);
-      
-  //     // Expected format: /V1/companycode/shortcode
-  //     if (pathComponents.length < 3 || pathComponents[0] !== 'V1') {
-  //       loggerRef.current.info(`Invalid universal link format: ${url.href}`);
-  //       return false;
-  //     }
+  // Handle universal links like https://insertaffiliate.link/companycode/shortcode
+  // Also supports legacy format: https://insertaffiliate.link/V1/companycode/shortcode
+  const handleUniversalLink = async (url: string): Promise<boolean> => {
+    try {
+      const pathMatch = url.match(/^https?:\/\/[^\/]+(\/.*)?$/);
+      const pathname = pathMatch?.[1] || '';
+      const pathComponents = pathname.split('/').filter(segment => segment.length > 0);
 
-  //     const companyCode = pathComponents[1];
-  //     const shortCode = pathComponents[2];
+      let companyCode: string;
+      let shortCode: string;
 
-  //     loggerRef.current.info(`Universal link detected - Company: ${companyCode}, Short code: ${shortCode}`);
+      if (pathComponents.length >= 3 && pathComponents[0] === 'V1') {
+        // Legacy format: /V1/companycode/shortcode
+        companyCode = pathComponents[1];
+        shortCode = pathComponents[2];
+      } else if (pathComponents.length >= 2) {
+        // Current format: /companycode/shortcode
+        companyCode = pathComponents[0];
+        shortCode = pathComponents[1];
+      } else {
+        loggerRef.current.info(`Invalid universal link format: ${url}`);
+        return false;
+      }
 
-  //     // Validate company code matches initialized one
-  //     const activeCompanyCode = await getActiveCompanyCode();
-  //     if (activeCompanyCode && companyCode.toLowerCase() !== activeCompanyCode.toLowerCase()) {
-  //       loggerRef.current.info(`Warning: URL company code (${companyCode}) doesn't match initialized company code (${activeCompanyCode})`);
-  //     }
+      loggerRef.current.info(`Universal link detected - Company: ${companyCode}, Short code: ${shortCode}`);
 
-  //     // Process the affiliate attribution
-  //     await storeInsertAffiliateIdentifier({ link: shortCode });
+      const activeCompanyCode = await getActiveCompanyCode();
+      if (activeCompanyCode && companyCode.toLowerCase() !== activeCompanyCode.toLowerCase()) {
+        loggerRef.current.info(`Warning: URL company code (${companyCode}) doesn't match initialized company code (${activeCompanyCode})`);
+      }
 
+      await storeInsertAffiliateIdentifier({ link: shortCode, source: 'universal_link' });
+      return true;
+    } catch (error) {
+      loggerRef.current.error('Error handling universal link:', error);
+      return false;
+    }
+  };
 
-  //     return true;
-  //   } catch (error) {
-  //     loggerRef.current.error('Error handling universal link:', error);
-  //     return false;
-  //   }
-  // };
+  // Handle universal links from custom domains (e.g. https://links.yourcompany.com/companycode/shortcode)
+  // iOS only delivers universal links for domains in the app's Associated Domains entitlement
+  const handleCustomDomainUniversalLink = async (url: string): Promise<boolean> => {
+    try {
+      const pathMatch = url.match(/^https?:\/\/[^\/]+(\/.*)?$/);
+      const pathname = pathMatch?.[1] || '';
+      const pathComponents = pathname.split('/').filter(segment => segment.length > 0);
+
+      if (pathComponents.length < 2) {
+        return false;
+      }
+
+      const urlCompanyCode = pathComponents[0];
+      const shortCode = pathComponents[1];
+
+      const activeCompanyCode = await getActiveCompanyCode();
+      if (!activeCompanyCode) return false;
+
+      if (urlCompanyCode.toLowerCase() !== activeCompanyCode.toLowerCase()) {
+        loggerRef.current.info(`Custom domain universal link company code (${urlCompanyCode}) doesn't match initialized company code (${activeCompanyCode}), ignoring`);
+        return false;
+      }
+
+      loggerRef.current.info(`Custom domain universal link detected - Short code: ${shortCode}`);
+      await storeInsertAffiliateIdentifier({ link: shortCode, source: 'universal_link' });
+      return true;
+    } catch (error) {
+      loggerRef.current.error('Error handling custom domain universal link:', error);
+      return false;
+    }
+  };
 
   // Parse short code from URL
   const parseShortCodeFromURL = (url: URL): string | null => {

--- a/src/DeepLinkIapProvider.tsx
+++ b/src/DeepLinkIapProvider.tsx
@@ -95,7 +95,8 @@ type AffiliateAssociationSource =
   | 'clipboard_match'    // iOS clipboard UUID match from backend
   | 'short_code_manual'  // Developer called setShortCode()
   | 'referring_link'     // Developer called setInsertAffiliateIdentifier()
-  | 'universal_link';    // iOS Universal Link (https://insertaffiliate.link/companycode/shortcode)
+  | 'universal_link'     // iOS Universal Link (https://insertaffiliate.link/companycode/shortcode)
+  | 'app_link';          // Android App Link (https://insertaffiliate.link/companycode/shortcode)
 
 // Logger interface for custom logging
 export type InsertAffiliateLogger = {
@@ -342,6 +343,14 @@ const DeepLinkIapProvider: React.FC<T_DEEPLINK_IAP_PROVIDER> = ({
     const handleDeepLink = async (url: string): Promise<boolean> => {
       try {
         verboseLog(`Platform detection: Platform.OS = ${Platform.OS}`);
+
+        // App Links (Android) and Universal Links (iOS) both use https://
+        // Route these through handleInsertLinks which handles both
+        if (url.startsWith('https://') || url.startsWith('http://')) {
+          verboseLog('Routing https URL to handleInsertLinks');
+          return await handleInsertLinks(url);
+        }
+
         if (Platform.OS === 'ios') {
           verboseLog('Routing to iOS handler (handleInsertLinks)');
           return await handleInsertLinks(url);
@@ -736,7 +745,7 @@ const DeepLinkIapProvider: React.FC<T_DEEPLINK_IAP_PROVIDER> = ({
         loggerRef.current.info(`Warning: URL company code (${companyCode}) doesn't match initialized company code (${activeCompanyCode})`);
       }
 
-      await storeInsertAffiliateIdentifier({ link: shortCode, source: 'universal_link' });
+      await storeInsertAffiliateIdentifier({ link: shortCode, source: Platform.OS === 'android' ? 'app_link' : 'universal_link' });
       return true;
     } catch (error) {
       loggerRef.current.error('Error handling universal link:', error);
@@ -768,7 +777,7 @@ const DeepLinkIapProvider: React.FC<T_DEEPLINK_IAP_PROVIDER> = ({
       }
 
       loggerRef.current.info(`Custom domain universal link detected - Short code: ${shortCode}`);
-      await storeInsertAffiliateIdentifier({ link: shortCode, source: 'universal_link' });
+      await storeInsertAffiliateIdentifier({ link: shortCode, source: Platform.OS === 'android' ? 'app_link' : 'universal_link' });
       return true;
     } catch (error) {
       loggerRef.current.error('Error handling custom domain universal link:', error);


### PR DESCRIPTION
## Summary
- Add `universal_link` and `app_link` source types
- Implement `handleUniversalLink` and `handleCustomDomainUniversalLink` for iOS
- Route Android `https://` URLs through `handleInsertLinks` for App Links support
- Platform-aware source: `universal_link` on iOS, `app_link` on Android
- Update README with Associated Domains, AndroidManifest intent filters, and testing guidance

## Test plan
- [x] Tested iOS Universal Links on iPhone (default + custom domain)
- [x] Tested Android App Links on Samsung device (default + custom domain)
- [x] Google Digital Asset Links verification passing